### PR TITLE
Avoid js error in addressbook when housenumber or addition are empty

### DIFF
--- a/view/frontend/templates/customer/address/Postcode.phtml
+++ b/view/frontend/templates/customer/address/Postcode.phtml
@@ -170,10 +170,10 @@ $addition = $block->getStreetLine(3);
             houseNumberValue = $('.field.street').find('.control input:eq('+streetLineId+')').val(),
             houseAdditionValue = $('.field.street').find('.control input:eq('+(streetLineId + 1)+')').val();
         if (!houseAdditionValue) {
-            houseNumberValue = <?= $block->escapeJs($houseNumber); ?>;
+            houseNumberValue = '<?= $block->escapeJs($houseNumber); ?>';
         }
         if (!houseAdditionValue) {
-            houseAdditionValue = <?= $block->escapeJs($addition); ?>;
+            houseAdditionValue = '<?= $block->escapeJs($addition); ?>';
         }
 
         var housenumberElement = $('.field.zip').clone();


### PR DESCRIPTION
In rare cases the housenumber field can be empty.
For housenumber addition it is normal to be empty. This breaks the postcode validation.

This fixes the error on the customer account addressbook page: Uncaught SyntaxError: Unexpected token ';'