### PR TITLE
pickup location delivery date false check

### DIFF
--- a/Controller/DeliveryOptions/Save.php
+++ b/Controller/DeliveryOptions/Save.php
@@ -183,7 +183,7 @@ class Save extends AbstractDeliveryOptions
         $params['quote_id'] = $this->checkoutSession->getQuoteId();
 
         // Recalculate the delivery date if it's unknown for pickup
-        if (!isset($params['date']) && $params['type'] == 'pickup') {
+        if ((!isset($params['date']) || !$params['date']) && $params['type'] == 'pickup') {
             $params['address']['country'] = $params['address']['Countrycode'];
             $params['address']['postcode'] = $params['address']['Zipcode'];
             $params['date'] = $this->getDeliveryDay($params['address']);


### PR DESCRIPTION
$this->checkoutSession->getPostNLDeliveryDate() can return false

```
$params['date'] = $this->checkoutSession->getPostNLDeliveryDate();
```

and !isset($params['date']) will return true since it has a value (false) and delivery date will not be recalculated 
