### PR TITLE
#385 fix issue where method code is 'null' for function strpos()

### DIFF
--- a/Plugin/Shipment/ShippingBuilder.php
+++ b/Plugin/Shipment/ShippingBuilder.php
@@ -34,6 +34,7 @@ class ShippingBuilder
         if ($shipping) {
             $method = $shipping->getMethod();
             if ($this->orderId &&
+                is_string($method) &&
                 strpos($method, 'tig_postnl') !== false &&
                 $extensionAttributes = $shipping->getExtensionAttributes()
             ) {


### PR DESCRIPTION
### Fix for #385

This PR addresses the issue where `strpos()` was being called with a potential `null` or non-string value for `$method`, which is deprecated in PHP 8.2.

**Changes:**
- Replaced the previous direct call to `strpos()` with a check using `is_string($method) && strpos($method, 'tig_postnl') !== false`.
- This ensures that `$method` is a string before attempting to use `strpos()`, thereby preventing any deprecation warnings and ensuring compatibility with PHP 8.2.

This update improves the stability of the code and ensures it behaves as expected without unnecessary checks.