### PR TITLE
Update ShippingBuilder.php

### DIFF
--- a/Plugin/Shipment/ShippingBuilder.php
+++ b/Plugin/Shipment/ShippingBuilder.php
@@ -43,7 +43,7 @@ class ShippingBuilder
                     /** @var ShipmentAttributeInterface $model */
                     $model = $this->shipmentAttributeFactory->create();
 
-                    $model->setProductCode($postnlOrder->getProductCode())
+                    $model->setProductCode($postnlOrder->getProductCode() ?? '')
                         ->setType((string)$postnlOrder->getType())
                         ->setShipAt((string)$postnlOrder->getShipAt())
                         ->setDeliveryDate($postnlOrder->getDeliveryDate())


### PR DESCRIPTION
Added check so productcode will be '' instead of null when missing. This will prevent an error on the orders overview in the backoffice.